### PR TITLE
fix(deps): add dependency confusion protection to workspace packages

### DIFF
--- a/notebooks/pyproject.toml
+++ b/notebooks/pyproject.toml
@@ -73,6 +73,7 @@ fixable = ["ALL"]
 unfixable = []
 
 [tool.uv]
+package = false
 constraint-dependencies = [
     "tornado>=6.5.5",
     "nbconvert>=7.17.0",

--- a/notebooks/uv.lock
+++ b/notebooks/uv.lock
@@ -1385,7 +1385,7 @@ wheels = [
 [[package]]
 name = "notebooks"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "amazon-ion" },
     { name = "amzn-smart-product-onboarding-metaclasses" },

--- a/packages/smart-product-onboarding/api/handlers/pyproject.toml
+++ b/packages/smart-product-onboarding/api/handlers/pyproject.toml
@@ -23,6 +23,12 @@ dev = [
     "moto[all]>=5.0.16",
 ]
 
+[tool.uv]
+publish = false
+
+[tool.uv.sources]
+amzn-smart-product-onboarding-api-runtime = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/smart-product-onboarding/api/runtime/pyproject.toml
+++ b/packages/smart-product-onboarding/api/runtime/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "aws-lambda-powertools[tracer,aws-sdk]>=2.28.0",
 ]
 
+[tool.uv]
+publish = false
+
 [tool.hatch.build.targets.wheel]
 packages = ["amzn_smart_product_onboarding_api_runtime"]
 

--- a/packages/smart-product-onboarding/core-utils/pyproject.toml
+++ b/packages/smart-product-onboarding/core-utils/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
     "hypothesis>=6.151.9",
 ]
 
+[tool.uv]
+publish = false
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/smart-product-onboarding/metaclasses/pyproject.toml
+++ b/packages/smart-product-onboarding/metaclasses/pyproject.toml
@@ -28,6 +28,13 @@ dev = [
     "boto3-stubs-lite[bedrock-runtime,s3,dynamodb]>=1.35.37",
 ]
 
+[tool.uv]
+publish = false
+
+[tool.uv.sources]
+amzn-smart-product-onboarding-api-runtime = { workspace = true }
+amzn-smart-product-onboarding-core-utils = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/smart-product-onboarding/product-categorization/pyproject.toml
+++ b/packages/smart-product-onboarding/product-categorization/pyproject.toml
@@ -26,6 +26,13 @@ dev = [
     "moto[all]>=5.0.16",
 ]
 
+[tool.uv]
+publish = false
+
+[tool.uv.sources]
+amzn-smart-product-onboarding-api-runtime = { workspace = true }
+amzn-smart-product-onboarding-core-utils = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/smart-product-onboarding/pyproject.toml
+++ b/packages/smart-product-onboarding/pyproject.toml
@@ -2,6 +2,7 @@
 # This is the root workspace configuration that manages all Python packages
 
 [tool.uv]
+package = false
 constraint-dependencies = [
     "multipart>=1.3.1",
     "joserfc>=1.6.3",


### PR DESCRIPTION
Mark all workspace member packages with `publish = false` to prevent accidental publishing to PyPI, mitigating dependency confusion attacks if packages are copied and used independently with uv.

Mark the workspace root and notebooks project with `package = false` since they are not distributable packages.

Also consolidate `[tool.uv.sources]` declarations into member packages (metaclasses, product-categorization, api/handlers) so workspace dependency resolution is explicit at the package level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
